### PR TITLE
Add .gitignore for Node.js, React, and Maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# ---- Node.js ----
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+package-lock.json
+*.tgz
+.env
+dist/
+build/
+.cache/
+
+# ---- React / Frontend ----
+/frontend/node_modules/
+/frontend/build/
+/frontend/.env
+/frontend/.cache/
+
+# ---- Java / Maven ----
+target/
+!.mvn/wrapper/maven-wrapper.jar
+.mvn/wrapper/maven-wrapper.properties
+*.class
+*.war
+*.ear
+*.jar
+
+# ---- IDE / Editors ----
+.idea/
+.vscode/
+*.iml
+*.swp
+
+# ---- OS specific ----
+.DS_Store
+Thumbs.db
+
+# ---- Logs ----
+logs/
+*.log
+*.out
+*.pid
+
+# ---- Test / Coverage ----
+coverage/
+.nyc_output/


### PR DESCRIPTION
This pull request adds a .gitignore file to the repository to improve project cleanliness and maintainability by excluding unnecessary files, including:

- Node.js dependencies (`node_modules/`)
- React build outputs and caches
- Maven target directory
- IDE/editor configuration files (.idea/, .vscode/)
- Log and coverage files
